### PR TITLE
Package Creator v1.1.0 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,5 @@ To be frank, this tool was made for personal use and the templates are configure
 
 ### Known Issues
 There are a couple of known issue with this tool and since it's for personal use, I might just overlook it. Anyways the issues for transparency:
-- The meta files don't get committed into the inital commit
-  - Workaround - Ammend the meta file changes into the initial commit
 - The asset database refresh doesn't work immediately and the newly added package isn't visible in the editor
-  - Workaround - Tab out of the editor and tab back in for the refresh to work correctly
+  - Workaround - Press CTRL + R to manually perform an asset database refresh

--- a/Scripts/PackageCreator.cs
+++ b/Scripts/PackageCreator.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using UnityEditor;
-using UnityEngine;
 
 namespace Hibzz.PackageCreator
 {
@@ -15,6 +12,8 @@ namespace Hibzz.PackageCreator
 		const string PACKAGE_JSON_PATH = TEMPLATE_PATH + "\\package.json.template";
 		const string LICENSE_PATH      = TEMPLATE_PATH + "\\license.template";
 		const string ASMDEF_PATH       = TEMPLATE_PATH + "\\asmdef.template";
+
+		public const string GIT_INIT_KEY = "HIBZZ_PC_GIT_INIT_PREFS_KEY";
 
 		static string name = "";
 		static string description = "";
@@ -51,11 +50,14 @@ namespace Hibzz.PackageCreator
 			var asmdef_content = ReadTemplate(ASMDEF_PATH);
 			File.WriteAllText($"{package_path}\\com.hibzz.{name.ToLower()}.asmdef", asmdef_content);
 
-			// initialize a git repository here
-			InitializeGitRepo(package_path);
-
-			// the asset database must be refreshed for the user to see the newly added package
+			// Refresh asset database doesn't work and I can't figure out the
+			// reason why... but anyways doing it so that in case in a later
+			// patch unity fixes this issue
 			AssetDatabase.Refresh();
+
+			// set the editor prefs string letting the next refresh know to do
+			// a git initialization
+			EditorPrefs.SetString(GIT_INIT_KEY, package_path);
 		}
 
 		/// <summary>
@@ -79,7 +81,7 @@ namespace Hibzz.PackageCreator
 		/// Initialize a git repo for the package
 		/// </summary>
 		/// <param name="path">The path to the newly created package</param>
-		static void InitializeGitRepo(string path)
+		public static void InitializeGitRepo(string path)
 		{
 			// > git init .
 			var init_process = new Process()

--- a/Scripts/PackageCreatorWindow.cs
+++ b/Scripts/PackageCreatorWindow.cs
@@ -31,8 +31,10 @@ namespace Hibzz.PackageCreator
 
 			// package description
 			GUILayout.Space(10);
+			EditorStyles.textField.wordWrap = true;
 			EditorGUILayout.PrefixLabel("Description");
 			packagedescription = EditorGUILayout.TextArea(packagedescription, GUILayout.Height(position.height - 110));
+			EditorStyles.textField.wordWrap = false;
 
 			// add a button
 			GUILayout.FlexibleSpace();
@@ -41,14 +43,8 @@ namespace Hibzz.PackageCreator
 				// close the window
 				Close();
 
-				// open progress bar
-				EditorUtility.DisplayProgressBar("Hibzz.Package Creator", $"Creating {packagename}...", 0.1f);
-
 				// create package
 				PackageCreator.CreatePackage(packagename, packagedescription);
-
-				// close the progress bar
-				EditorUtility.ClearProgressBar();
 			}
 
 			GUILayout.EndArea();

--- a/Scripts/PostProcessor.cs
+++ b/Scripts/PostProcessor.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace Hibzz.PackageCreator
+{
+    public class PostProcessor : AssetPostprocessor
+    {
+		static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
+		{
+			// Get the path where to initialize the git repository...
+			// If there's no value found, we skip this process
+			var git_init_path = EditorPrefs.GetString(PackageCreator.GIT_INIT_KEY, null);
+			if(string.IsNullOrWhiteSpace(git_init_path)) { return; }
+
+			// initialize the git repository
+			PackageCreator.InitializeGitRepo(git_init_path);
+
+			// now that the git repository has been initialized, we don't want
+			// to initialize a repo every time a domain reload happens...
+			// so clear the key
+			EditorPrefs.DeleteKey(PackageCreator.GIT_INIT_KEY); 
+		}
+	}
+}

--- a/Scripts/PostProcessor.cs.meta
+++ b/Scripts/PostProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6506a2b1bf206ac418ba0460f3ebd3e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.hibzz.packagecreator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "displayName": "hibzz.packagecreator",
   "description": "A tool to easily create packages from the Unity Editor",
   "author": {


### PR DESCRIPTION
This update adds a whole bunch of fixes and changes to the Package Creator. These are the following changes:
- Git repo initialization now starts after the domain reload and includes the meta files in the initial commit
- The text in the description box properly wraps around
- Removed the progress bar because the task is instantaneous and the bar feels useless