### PR TITLE
Moved button location to Hibzz > Package Creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Alternatively, you can download the latest release from the [releases page](http
 <br>
 
 ## Usage
-To be frank, this tool was made for personal use and the templates are configured for Hibzz Games. So, please fork the repo and make the appropriate changes to the template to use it. The package creation process can be triggered by pressing the `Launch Package Creator` button under the `Windows` tab.
+To be frank, this tool was made for personal use and the templates are configured for Hibzz Games. So, please fork the repo and make the appropriate changes to the template to use it. The package creation process can be triggered by pressing the `Package Creator` button under the `Hibzz` tab.
 
 <br>
 

--- a/Scripts/PackageCreatorWindow.cs
+++ b/Scripts/PackageCreatorWindow.cs
@@ -5,7 +5,7 @@ namespace Hibzz.PackageCreator
 {
 	internal class PackageCreatorWindow : EditorWindow
 	{
-		[MenuItem("Window/Launch Package Creator")]
+		[MenuItem("Hibzz/Package Creator")]
 		static void OpenPackageCreator()
 		{
 			// open package creator editor window

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.hibzz.packagecreator",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "displayName": "hibzz.packagecreator",
   "description": "A tool to easily create packages from the Unity Editor",
   "author": {


### PR DESCRIPTION
Instead of adding the triggers for many of my tools all over the place in the Unity editor, I want them to be simple and easy to find. This is an attempt to unify all of my tools under the Hibzz tab such that it's easier to access.

I'm thinking about making this tool more generic such that users can modify the tool as they want by directly using it, instead of forking it. It's heavily unlikely, but I am considering it.